### PR TITLE
fix double slash in copy path, install init

### DIFF
--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -14,6 +14,6 @@ sed -i -e "s#$config->ps_generated.\+#$config->ps_generated = \"${THUMBS}\";#" /
 fi
 
 # patch in fixed keyboard.js file
-cp /defaults/keyboard.js /config/www//PhotoShow/src/js/keyboard.js
+cp /defaults/keyboard.js /config/www/PhotoShow/src/js/keyboard.js
 sed -i -e "s@\$config->timezone.*@\$config->timezone = \"${TZ}\"@g" /config/www/PhotoShow/config.php
 chown -R abc:abc /config/www/PhotoShow /Thumbs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ remove extraneous slash in copy operation, install init.