### PR TITLE
Updated Dockerfile to include zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
 	imagemagick \
 	jq \
 	php7-gd \
+	zip \
 	php7-imagick && \
  echo "**** Tag this image with current version ****" && \
  if [ -z ${PHOTOSHOW_COMMIT+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,6 +15,7 @@ RUN \
 	imagemagick \
 	jq \
 	php7-gd \
+	zip \
 	php7-imagick && \
  echo "**** Tag this image with current version ****" && \
  if [ -z ${PHOTOSHOW_COMMIT+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,6 +15,7 @@ RUN \
 	imagemagick \
 	jq \
 	php7-gd \
+	zip \
 	php7-imagick && \
  echo "**** Tag this image with current version ****" && \
  if [ -z ${PHOTOSHOW_COMMIT+x} ]; then \


### PR DESCRIPTION
Downloading whole albums requires zip. This can be done on the main page of an album. Without zip installed, an empty zip file is sent to the user